### PR TITLE
Add Pipfile to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .coverage
 local.py
 package-lock.json
+Pipfile
 Pipfile.lock
 node_modules/
 media/


### PR DESCRIPTION
When installing deps with `pipenv install -r requirements-dev.txt` it generates a `Pipfile` that is versioned.